### PR TITLE
Introduce AttributeFilterException to make the throw clause of methods AttributerFilter.filter() and AttributeContext.proceed() consistent, allowing an exception originating from proceed() to bubble up without handling halfway.

### DIFF
--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeContext.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeContext.java
@@ -17,11 +17,10 @@ public abstract class AttributeContext {
      * {@link AttributeFilter} or finally to the setter method if there is no
      * more {@link AttributeFilter}s. If you do not call this method, the value
      * is never set to the component.
-     * 
-     * @throws Exception
-     *             in case of an error.
+     *
+     * @throws AttributeFilterException on failure.
      */
-    public abstract void proceed() throws Exception;
+    public abstract void proceed() throws AttributeFilterException;
 
     public Object getValue() {
         return value;

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeFilter.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeFilter.java
@@ -19,7 +19,8 @@ public interface AttributeFilter {
      * 
      * @param attributeContext
      *            context for the filtering.
+     * @throws AttributeFilterException on failures.
      */
-    void filter(AttributeContext attributeContext);
+    void filter(AttributeContext attributeContext) throws AttributeFilterException;
 
 }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeFilterException.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/filter/AttributeFilterException.java
@@ -1,0 +1,18 @@
+package org.vaadin.teemu.clara.inflater.filter;
+
+@SuppressWarnings("serial")
+public class AttributeFilterException extends RuntimeException {
+
+    public AttributeFilterException(String message) {
+        super(message);
+    }
+
+    public AttributeFilterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AttributeFilterException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/clara/src/test/java/org/vaadin/teemu/clara/ClaraTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/ClaraTest.java
@@ -1,12 +1,9 @@
 package org.vaadin.teemu.clara;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.InputStream;
-
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Layout;
+import com.vaadin.ui.VerticalLayout;
 import org.junit.Before;
 import org.junit.Test;
 import org.vaadin.teemu.clara.binder.annotation.UiField;
@@ -15,10 +12,12 @@ import org.vaadin.teemu.clara.inflater.LayoutInflaterException;
 import org.vaadin.teemu.clara.inflater.filter.AttributeContext;
 import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
 
-import com.vaadin.ui.Button;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.Layout;
-import com.vaadin.ui.VerticalLayout;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ClaraTest {
 
@@ -205,11 +204,7 @@ public class ClaraTest {
                         attributeContext.setValue("filteredValue");
                     }
                 }
-                try {
-                    attributeContext.proceed();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+                attributeContext.proceed();
             }
         };
     }
@@ -225,11 +220,7 @@ public class ClaraTest {
                         attributeContext.setValue("filteredTwice");
                     }
                 }
-                try {
-                    attributeContext.proceed();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+                attributeContext.proceed();
             }
         };
     }

--- a/clara/src/test/java/org/vaadin/teemu/clara/inflater/LayoutInflaterTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/inflater/LayoutInflaterTest.java
@@ -1,19 +1,5 @@
 package org.vaadin.teemu.clara.inflater;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.vaadin.teemu.clara.Clara;
-import org.vaadin.teemu.clara.inflater.filter.AttributeContext;
-import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
-import org.vaadin.teemu.clara.inflater.handler.AttributeHandlerException;
-
 import com.vaadin.server.Sizeable.Unit;
 import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.shared.ui.label.ContentMode;
@@ -26,6 +12,19 @@ import com.vaadin.ui.Label;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.VerticalLayout;
+import org.junit.Before;
+import org.junit.Test;
+import org.vaadin.teemu.clara.Clara;
+import org.vaadin.teemu.clara.inflater.filter.AttributeContext;
+import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
+import org.vaadin.teemu.clara.inflater.handler.AttributeHandlerException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class LayoutInflaterTest {
 
@@ -198,11 +197,7 @@ public class LayoutInflaterTest {
                         attributeContext.setValue("filteredValue");
                     }
                 }
-                try {
-                    attributeContext.proceed();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+                attributeContext.proceed();
             }
         };
 
@@ -225,7 +220,7 @@ public class LayoutInflaterTest {
 
         // check that the id my-button returns a Button
         assertEquals(com.vaadin.ui.Button.class,
-                Clara.findComponentById(view, "myButton").getClass());
+            Clara.findComponentById(view, "myButton").getClass());
 
         // check that non-existing id returns null
         assertEquals(null, Clara.findComponentById(view, "non-existing-id"));


### PR DESCRIPTION
Hi Teemu,

As you may have heard from Michael Tzukanov, our team at bol.com recently started a new application using Vaadin.
I very much push my team to use declarative UIs, as I am in real favour of making clear cuts between UI structure and behaviour. We looked at both Clara and the new native declarative UIs of Vaadin and for us Clara is the winner, with real XML and prety straight-forward XML structure.

To use Clara to the full extend in our application I like you to incorporate some refinements, which I will offer you in separate pull-requests. 
This one is about improved handling of exceptions in the AttributeFilter, while the second is about preparation for extending Clara locally with ability to instantiate custom components from a Spring container. I expect another request to follow shortly that will deal with serialisation issues caused by the Clara Binder class.

Please, let me know what you think about them.

Cheers,

Mark (mkoops@bol.com)