### PR TITLE
Unwrap InvocationTargetException in ListenerInvocationHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 .settings
 widgetsets/
 gwt-unitCache/
+.idea/
+*.iml

--- a/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
@@ -198,7 +198,7 @@ public class Binder {
             } catch (IllegalAccessException e) {
                 throw new BinderException(e);
             } catch (InvocationTargetException e) {
-                throw new BinderException(e);
+                throw new BinderException(e.getCause());
             }
         }
     }
@@ -341,7 +341,7 @@ public class Binder {
         } catch (IllegalAccessException e) {
             throw new BinderException(e);
         } catch (InvocationTargetException e) {
-            throw new BinderException(e);
+            throw new BinderException(e.getCause());
         }
     }
 

--- a/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
@@ -235,17 +235,21 @@ public class Binder {
         @Override
         public Object invoke(Object proxy, Method method, Object[] args)
                 throws Throwable {
-            if (args != null && args.length > 0
-                    && eventClass.isAssignableFrom(args[0].getClass())) {
+            try {
+                if (args != null && args.length > 0
+                        && eventClass.isAssignableFrom(args[0].getClass())) {
+                    getLogger().fine(
+                            String.format("Forwarding method call %s -> %s.",
+                                    method.getName(), listenerMethod.getName()));
+                    return listenerMethod.invoke(controller, args);
+                }
                 getLogger().fine(
-                        String.format("Forwarding method call %s -> %s.",
-                                method.getName(), listenerMethod.getName()));
-                return listenerMethod.invoke(controller, args);
+                        String.format("Forwarding method call %s to %s.",
+                                method.getName(), controller.getClass()));
+                return method.invoke(controller, args);
+            } catch (InvocationTargetException ex) {
+                throw ex.getCause();
             }
-            getLogger().fine(
-                    String.format("Forwarding method call %s to %s.",
-                            method.getName(), controller.getClass()));
-            return method.invoke(controller, args);
         }
 
         private Logger getLogger() {

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
@@ -114,7 +114,7 @@ public class AttributeHandler {
         } catch (IllegalAccessException e) {
             throw new AttributeHandlerException(e);
         } catch (InvocationTargetException e) {
-            throw new AttributeHandlerException(e);
+            throw new AttributeHandlerException(e.getCause());
         }
     }
 

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/LayoutAttributeHandler.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/LayoutAttributeHandler.java
@@ -60,7 +60,7 @@ public class LayoutAttributeHandler extends AttributeHandler {
         } catch (IllegalAccessException e) {
             throw new AttributeHandlerException(e);
         } catch (InvocationTargetException e) {
-            throw new AttributeHandlerException(e);
+            throw new AttributeHandlerException(e.getCause());
         }
     }
 


### PR DESCRIPTION
This changes the `Binder.ListenerInvocationHandler` to unwrap the `InvocationTargetException` thrown when an exception occurs in the reflective `Method.invoke`.

This will make the stacktraces of (runtime) exceptions in the event method similar to those in a 'normal' Vaadin event handler (ie: they no longer contain `UndeclaredThrowableException` and `InvocationTargetException` which might obscure the real cause).

(+ adding IntelliJ project files to .gitignore)