### PR TITLE
More control over component creation, prefixed ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,45 @@ AttributeFilter filter = new AttributeFilter() {
     }
 };
 ```
+
+## Advanced control over component creation
+
+### ```ClaraBuilder```
+
+Occasionally you need extra control over the creation of the component tree. The class ```ClaraBuilder``` supports adding ```AttributeFilter``` and extra ```AttributeParser``` instances. 
+
+You can also set a common prefix that is used for all ids read from the XML definition. The primary use case for setting an id prefix is to be able to generate page-wide unique ids in combination with custom, reusable components that use Clara internally to build themselves; it is advisable to combine this with ```InflaterListener```.
+
+An example of using ```ClaraBuilder```:
+
+```java
+Clara.build()
+        .withController(this)
+        .withIdPrefix("example.")
+        .withAttributeFilter(new InternationalizationFilter())
+        .withAttributeParser(new ResourceParser())
+        .createFrom("example-ui.xml");
+```
+
+When you use an id prefix, the binding with the ```@UiField```, ```@UiHandler``` and ```@UiDataSource``` still use the id without prefix (that is: the id defined in the XML).
+
+### ```InflaterListener```
+
+Components can be notified by Clara when they have been fully constructed, all their children have been created and all attributes have been set by implementing ```org.vaadin.teemu.clara.inflater.InflaterListener```. This allows a component to do additional construction work that requires knowledge of - for example - the attribute values set from XML.
+
+As an example, a custom component that itself uses Clara for its definition could build its component tree from the ```InflaterListener#componentInflated()``` method and use its own id as the id prefix. This can help with creating page-wide unique ids.
+
+An example:
+
+```java
+public class SomeCustomComponent extend CustomComponent implements InflaterListener {
+    @Override
+    public void componentInflated() {
+        Component root = Clara.build()
+                .withIdPrefix(getId())
+                .withController(this)
+                .createFrom("SomeCustomComponent.xml")
+         setCompositionRoot(root);
+    }
+}
+```

--- a/clara/src/main/java/org/vaadin/teemu/clara/Clara.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/Clara.java
@@ -2,9 +2,7 @@ package org.vaadin.teemu.clara;
 
 import java.io.InputStream;
 
-import org.vaadin.teemu.clara.binder.Binder;
 import org.vaadin.teemu.clara.binder.BinderException;
-import org.vaadin.teemu.clara.inflater.LayoutInflater;
 import org.vaadin.teemu.clara.inflater.LayoutInflaterException;
 import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
 
@@ -13,6 +11,16 @@ import com.vaadin.ui.ComponentContainer;
 import com.vaadin.ui.HasComponents;
 
 public class Clara {
+
+    /**
+     * Creates an instance of {@link ClaraBuilder} that allows for more control
+     * over the way Clara instantiates a component.
+     *
+     * @return Builder object
+     */
+    public static ClaraBuilder build() {
+        return new ClaraBuilder();
+    }
 
     /**
      * Returns a {@link Component} that is read from the XML representation
@@ -57,21 +65,10 @@ public class Clara {
      */
     public static Component create(InputStream xml, Object controller,
             AttributeFilter... attributeFilters) {
-        Binder binder = new Binder();
-
-        // Inflate the XML to a component (tree).
-        LayoutInflater inflater = new LayoutInflater();
-        if (attributeFilters != null) {
-            for (AttributeFilter filter : attributeFilters) {
-                inflater.addAttributeFilter(filter);
-            }
-        }
-        Component result = inflater.inflate(xml,
-                binder.getAlreadyAssignedFields(controller));
-
-        // Bind to controller.
-        binder.bind(result, controller);
-        return result;
+        return new ClaraBuilder()
+                .withController(controller)
+                .withAttributeFilters(attributeFilters)
+                .createFrom(xml);
     }
 
     /**

--- a/clara/src/main/java/org/vaadin/teemu/clara/Clara.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/Clara.java
@@ -14,7 +14,7 @@ public class Clara {
 
     /**
      * Creates an instance of {@link ClaraBuilder} that allows for more control
-     * over the way Clara instantiates a component.
+     * over instantion of components by Clara.
      *
      * @return Builder object
      */
@@ -27,7 +27,7 @@ public class Clara {
      * given as {@link InputStream}. If you would like to bind the resulting
      * {@link Component} to a controller object, you should use
      * {@link #create(InputStream, Object, AttributeFilter...)} method instead.
-     * 
+     *
      * @param xml
      *            XML representation.
      * @return a {@link Component} that is read from the XML representation.
@@ -40,13 +40,12 @@ public class Clara {
      * Returns a {@link Component} that is read from the XML representation
      * given as {@link InputStream} and binds the resulting {@link Component} to
      * the given {@code controller} object.
-     * 
-     * <br>
-     * <br>
+     * <p>
      * Optionally you may also provide {@link AttributeFilter}s to do some
      * modifications (or example localized translations) to any attributes
      * present in the XML representation.
-     * 
+     * </p>
+     *
      * @param xml
      *            XML representation.
      * @param controller
@@ -57,7 +56,7 @@ public class Clara {
      *            modifications.
      * @return a {@link Component} that is read from the XML representation and
      *         bound to the given {@code controller}.
-     * 
+     *
      * @throws LayoutInflaterException
      *             if an error is encountered during the layout inflation.
      * @throws BinderException
@@ -75,21 +74,19 @@ public class Clara {
      * Returns a {@link Component} that is read from an XML file in the
      * classpath and binds the resulting {@link Component} to the given
      * {@code controller} object.
-     * 
-     * <br>
-     * <br>
+     * <p>
      * The filename is given either as a path relative to the class of the
      * {@code controller} object or as an absolute path. For example if you have
      * a {@code MyController.java} and {@code MyController.xml} files in the
      * same package, you can call this method like
      * {@code Clara.create("MyController.xml", new MyController())}.
-     * 
-     * <br>
-     * <br>
+     * </p>
+     * <p>
      * Optionally you may also provide {@link AttributeFilter}s to do some
      * modifications (or example localized translations) to any attributes
      * present in the XML representation.
-     * 
+     * </p>
+     *
      * @param xmlClassResourceFileName
      *            filename of the XML representation (within classpath, relative
      *            to {@code controller}'s class or absolute path).
@@ -101,7 +98,7 @@ public class Clara {
      *            modifications.
      * @return a {@link Component} that is read from the XML representation and
      *         bound to the given {@code controller}.
-     * 
+     *
      * @throws LayoutInflaterException
      *             if an error is encountered during the layout inflation.
      * @throws BinderException
@@ -118,14 +115,19 @@ public class Clara {
      * Searches the given component hierarchy {@code root} for a
      * {@link Component} with the given {@code componentId} as its {@code id}
      * property (see {@link Component#setId(String)}).
-     * 
-     * <br>
-     * <br>
+     * <p>
      * If the given {@code root} is a {@link ComponentContainer}, this method
      * will recursively iterate the component hierarchy in search for the
      * correct {@link Component}. Otherwise if the given {@code root} is a
      * single {@link Component}, only it is checked for its {@code id} value.
-     * 
+     * </p>
+     * <p>
+     * <b>Warning</b>: if you use this method to search for a component created
+     * with an id prefix (see {@link ClaraBuilder#withIdPrefix(String)}, then
+     * this method will only find the component if the prefix is included in
+     * {@code componentId}. You can also use {@link #findComponentById(Component, String, String)}.
+     * </p>
+     *
      * @param root
      *            root of a component tree (non-{@code null}).
      * @param componentId
@@ -135,6 +137,7 @@ public class Clara {
      * @throws IllegalArgumentException
      *             if either of the given parameters is {@code null}.
      * @see Component#setId(String)
+     * @see #findComponentById(Component, String, String)
      */
     public static Component findComponentById(Component root, String componentId) {
         // Check for null before doing anything.
@@ -159,6 +162,39 @@ public class Clara {
             }
         }
         return null;
+    }
+
+    /**
+     * Searches the given component hierarchy {@code root} for a
+     * {@link Component} with the given {@code idPrefix} and {@code componentId}
+     * as its {@code id} property (see {@link Component#setId(String)}).
+     * <p>
+     * If the given {@code root} is a {@link ComponentContainer}, this method
+     * will recursively iterate the component hierarchy in search for the
+     * correct {@link Component}. Otherwise if the given {@code root} is a
+     * single {@link Component}, only it is checked for its {@code id} value.
+     * </p>
+     *
+     * @param root
+     *         root of a component tree (non-{@code null}).
+     * @param idPrefix
+     *         Prefix of the id (empty string is used when {@code null})
+     * @param componentId
+     *         {@code id} of a component to search for (non-{@code null}).
+     * @return {@link Component} with a given {@code idPrefix} and
+     * {@code componentId} as its {@code id} or {@code null} if no such
+     * component is found.
+     * @throws IllegalArgumentException
+     *         if either of the given parameters is {@code null}.
+     * @see Component#setId(String)
+     * @see #findComponentById(Component, String, String)
+     */
+    public static Component findComponentById(Component root, String idPrefix, String componentId) {
+        if (idPrefix != null && !"".equals(idPrefix)) {
+            componentId = idPrefix + componentId;
+        }
+
+        return findComponentById(root, componentId);
     }
 
 }

--- a/clara/src/main/java/org/vaadin/teemu/clara/ClaraBuilder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/ClaraBuilder.java
@@ -1,0 +1,155 @@
+package org.vaadin.teemu.clara;
+
+import com.vaadin.ui.Component;
+import org.vaadin.teemu.clara.binder.Binder;
+import org.vaadin.teemu.clara.binder.BinderException;
+import org.vaadin.teemu.clara.inflater.LayoutInflater;
+import org.vaadin.teemu.clara.inflater.LayoutInflaterException;
+import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
+import org.vaadin.teemu.clara.inflater.parser.AttributeParser;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builder for configuring Clara.
+ *
+ * @author <a href="mailto:mrotteveel@bol.com">Mark Rotteveel</a>
+ */
+public class ClaraBuilder {
+
+    private Object controller;
+    private final List<AttributeFilter> attributeFilters = new ArrayList<AttributeFilter>();
+    private final List<AttributeParser> attributeParsers = new ArrayList<AttributeParser>();
+
+    /**
+     * Assigns the controller to the builder.
+     *
+     * @param controller
+     *         Controller object for binding component fields ({@code null} allowed).
+     * @return this builder
+     */
+    public ClaraBuilder withController(Object controller) {
+        this.controller = controller;
+        return this;
+    }
+
+    public Object getController() {
+        return controller;
+    }
+
+    /**
+     * Adds an attribute filter.
+     *
+     * @param filter
+     *         Attribute filter
+     * @return this builder
+     */
+    public ClaraBuilder withAttributeFilter(AttributeFilter filter) {
+        attributeFilters.add(filter);
+        return this;
+    }
+
+    /**
+     * Adds attribute filters.
+     *
+     * @param filters
+     *         Attribute filters
+     * @return this builder
+     */
+    public ClaraBuilder withAttributeFilters(AttributeFilter... filters) {
+        attributeFilters.addAll(Arrays.asList(filters));
+        return this;
+    }
+
+    /**
+     * @return Unmodifiable list of the current attribute filters
+     */
+    public List<AttributeFilter> getAttributeFilters() {
+        return Collections.unmodifiableList(attributeFilters);
+    }
+
+    /**
+     * Adds an attribute parser.
+     * <p>
+     * The attribute parsers added are in addition to the defaults parsers:
+     * <ul>
+     * <li>{@link org.vaadin.teemu.clara.inflater.parser.PrimitiveAttributeParser}</li>
+     * <li>{@link org.vaadin.teemu.clara.inflater.parser.VaadinAttributeParser}</li>
+     * <li>{@link org.vaadin.teemu.clara.inflater.parser.EnumAttributeParser}</li>
+     * <li>{@link org.vaadin.teemu.clara.inflater.parser.ComponentPositionParser}</li>
+     * </ul>
+     * </p>
+     *
+     * @param parser
+     *         Attribute parser
+     * @return this builder
+     */
+    public ClaraBuilder withAttributeParser(AttributeParser parser) {
+        attributeParsers.add(parser);
+        return this;
+    }
+
+    /**
+     * Adds attribute filters.
+     *
+     * @param parsers
+     *         Attribute parsers
+     * @return this builder
+     * @see #withAttributeParser(AttributeParser)
+     */
+    public ClaraBuilder withAttributeParsers(AttributeParser... parsers) {
+        attributeParsers.addAll(Arrays.asList(parsers));
+        return this;
+    }
+
+    /**
+     * @return Unmodifiable list of the current attribute parsers
+     */
+    public List<AttributeParser> getAttributeParsers() {
+        return Collections.unmodifiableList(attributeParsers);
+    }
+
+    /**
+     * Returns a {@link Component} that is read from the XML representation given
+     * as {@link InputStream} and binds the resulting {@link Component} to the
+     * {@code controller} object set in this builder.
+     *
+     * @param xml
+     *         XML representation.
+     * @return a {@link Component} that is read from the XML representation and
+     * bound to the given {@code controller}.
+     * @throws LayoutInflaterException
+     *         if an error is encountered during the layout inflation.
+     * @throws BinderException
+     *         if an error is encountered during the binding.
+     */
+    public Component createFrom(InputStream xml) {
+        Binder binder = new Binder();
+
+        // Inflate the XML to a component (tree).
+        LayoutInflater inflater = createInflater();
+        Component result = inflater.inflate(xml,
+                binder.getAlreadyAssignedFields(controller));
+
+        // Bind to controller.
+        binder.bind(result, controller);
+        return result;
+    }
+
+    LayoutInflater createInflater() {
+        LayoutInflater inflater = new LayoutInflater();
+        for (AttributeFilter filter : attributeFilters) {
+            inflater.addAttributeFilter(filter);
+        }
+
+        for (AttributeParser parser : attributeParsers) {
+            inflater.addAttributeParser(parser);
+        }
+
+        return inflater;
+    }
+}

--- a/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
@@ -32,6 +32,16 @@ import com.vaadin.ui.Component;
 
 public class Binder {
 
+    private final String idPrefix;
+
+    public Binder() {
+        this(null);
+    }
+
+    public Binder(String idPrefix) {
+        this.idPrefix = idPrefix != null ? idPrefix : "";
+    }
+
     protected Logger getLogger() {
         return Logger.getLogger(Binder.class.getName());
     }
@@ -90,6 +100,8 @@ public class Binder {
                     field.setAccessible(true);
                     Object value = field.get(controller);
                     if (value instanceof Component) {
+                        // We are intentionally not using the idPrefix here
+                        // The specific use in the inflater doesn't need the prefix
                         assignedFields.put(extractComponentId(field),
                                 (Component) value);
                     }
@@ -347,9 +359,11 @@ public class Binder {
     }
 
     private Component tryToFindComponentById(Component root, String id) {
-        Component component = Clara.findComponentById(root, id);
+        Component component = Clara.findComponentById(root, idPrefix, id);
         if (component == null) {
-            throw new BinderException("No component found for id: " + id + ".");
+            throw new BinderException(
+                    String.format("No component found for id: %1$s (%2$s%1$s).",
+                            id, idPrefix));
         }
         return component;
     }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/InflaterListener.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/InflaterListener.java
@@ -1,0 +1,19 @@
+package org.vaadin.teemu.clara.inflater;
+
+/**
+ * Listener interface for inflater actions.
+ * <p>
+ * An example use case is when a custom component needs to perform additional
+ * actions on (after) creation that require the attributes to have been set.
+ * </p>
+ *
+ * @author <a href="mailto:mrotteveel@bol.com">Mark Rotteveel</a>
+ */
+public interface InflaterListener {
+
+    /**
+     * Called by the inflater when all attributes and sub-components have been
+     * created.
+     */
+    void componentInflated();
+}

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
 import org.vaadin.teemu.clara.inflater.handler.AttributeHandler;
 import org.vaadin.teemu.clara.inflater.handler.LayoutAttributeHandler;
+import org.vaadin.teemu.clara.inflater.parser.AttributeParser;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -34,6 +35,7 @@ public class LayoutInflater {
     static final String DEFAULT_NAMESPACE = IMPORT_URN_PREFIX + "com.vaadin.ui";
 
     private List<AttributeFilter> attributeFilters = new ArrayList<AttributeFilter>();
+    private List<AttributeParser> extraAttributeParsers = new ArrayList<AttributeParser>();
 
     protected Logger getLogger() {
         return Logger.getLogger(LayoutInflater.class.getName());
@@ -114,6 +116,10 @@ public class LayoutInflater {
         attributeFilters.remove(attributeFilter);
     }
 
+    public void addAttributeParser(AttributeParser attributeParser) {
+        extraAttributeParsers.add(attributeParser);
+    }
+
     private class LayoutInflaterContentHandler extends DefaultHandler {
 
         private static final String ID_ATTRIBUTE = "id";
@@ -130,7 +136,8 @@ public class LayoutInflater {
                 ComponentProvider... componentProviders) {
             this.componentProviders = Arrays.asList(componentProviders);
 
-            attributeHandler = new AttributeHandler(attributeFilters);
+            attributeHandler = new AttributeHandler(attributeFilters,
+                    extraAttributeParsers);
             layoutAttributeHandler = new LayoutAttributeHandler(
                     attributeFilters);
         }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
@@ -36,7 +36,6 @@ public class LayoutInflater {
 
     private List<AttributeFilter> attributeFilters = new ArrayList<AttributeFilter>();
     private List<AttributeParser> extraAttributeParsers = new ArrayList<AttributeParser>();
-    private String idPrefix = "";
 
     protected Logger getLogger() {
         return Logger.getLogger(LayoutInflater.class.getName());
@@ -119,10 +118,6 @@ public class LayoutInflater {
 
     public void addAttributeParser(AttributeParser attributeParser) {
         extraAttributeParsers.add(attributeParser);
-    }
-
-    public void setIdPrefix(String idPrefix) {
-        this.idPrefix = idPrefix != null ? idPrefix : "";
     }
 
     private class LayoutInflaterContentHandler extends DefaultHandler {
@@ -260,9 +255,6 @@ public class LayoutInflater {
                     // Namespace matches -> add to map.
                     String value = attributes.getValue(i);
                     String name = attributes.getLocalName(i);
-                    if (ID_ATTRIBUTE.equals(name) && value != null) {
-                        value = idPrefix + value;
-                    }
                     attributeMap.put(name, value);
                 }
             }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/LayoutInflater.java
@@ -36,6 +36,7 @@ public class LayoutInflater {
 
     private List<AttributeFilter> attributeFilters = new ArrayList<AttributeFilter>();
     private List<AttributeParser> extraAttributeParsers = new ArrayList<AttributeParser>();
+    private String idPrefix = "";
 
     protected Logger getLogger() {
         return Logger.getLogger(LayoutInflater.class.getName());
@@ -118,6 +119,10 @@ public class LayoutInflater {
 
     public void addAttributeParser(AttributeParser attributeParser) {
         extraAttributeParsers.add(attributeParser);
+    }
+
+    public void setIdPrefix(String idPrefix) {
+        this.idPrefix = idPrefix != null ? idPrefix : "";
     }
 
     private class LayoutInflaterContentHandler extends DefaultHandler {
@@ -204,6 +209,9 @@ public class LayoutInflater {
                 }
                 currentContainer = (ComponentContainer) parent;
             }
+            if (component instanceof InflaterListener) {
+                ((InflaterListener) component).componentInflated();
+            }
         }
 
         private Component instantiateComponent(String uri, String localName,
@@ -252,6 +260,9 @@ public class LayoutInflater {
                     // Namespace matches -> add to map.
                     String value = attributes.getValue(i);
                     String name = attributes.getLocalName(i);
+                    if (ID_ATTRIBUTE.equals(name) && value != null) {
+                        value = idPrefix + value;
+                    }
                     attributeMap.put(name, value);
                 }
             }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
@@ -31,13 +31,19 @@ public class AttributeHandler {
     private final List<AttributeFilter> attributeFilters;
 
     public AttributeHandler(List<AttributeFilter> attributeFilters) {
+        this(attributeFilters, Collections.<AttributeParser>emptyList());
+    }
+
+    public AttributeHandler(List<AttributeFilter> attributeFilters, List<AttributeParser> extraAttributeParsers) {
         this.attributeFilters = attributeFilters;
 
-        // Setup the default AttributeHandlers.
+        // Setup the default AttributeParsers.
         attributeParsers.add(new PrimitiveAttributeParser());
         attributeParsers.add(new VaadinAttributeParser());
         attributeParsers.add(new EnumAttributeParser());
         attributeParsers.add(new ComponentPositionParser());
+        // Add extra AttributeParsers
+        attributeParsers.addAll(extraAttributeParsers);
     }
 
     /**

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/LayoutAttributeHandler.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/LayoutAttributeHandler.java
@@ -4,6 +4,7 @@ import static org.vaadin.teemu.clara.util.ReflectionUtils.findMethods;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +20,12 @@ public class LayoutAttributeHandler extends AttributeHandler {
     private static final String LAYOUT_ATTRIBUTE_NAMESPACE = "urn:vaadin:parent";
 
     public LayoutAttributeHandler(List<AttributeFilter> attributeFilters) {
-        super(attributeFilters);
+        this(attributeFilters, Collections.<AttributeParser>emptyList());
+    }
+
+    public LayoutAttributeHandler(List<AttributeFilter> attributeFilters,
+            List<AttributeParser> attributeParsers) {
+        super(attributeFilters, attributeParsers);
     }
 
     @Override

--- a/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
@@ -1,0 +1,188 @@
+package org.vaadin.teemu.clara;
+
+import com.vaadin.ui.Component;
+import org.junit.Test;
+import org.vaadin.teemu.clara.inflater.LayoutInflater;
+import org.vaadin.teemu.clara.inflater.filter.AttributeContext;
+import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
+import org.vaadin.teemu.clara.inflater.filter.AttributeFilterException;
+import org.vaadin.teemu.clara.inflater.parser.AttributeParser;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ClaraBuilder}.
+ *
+ * @author <a href="mailto:mrotteveel@bol.com>Mark Rotteveel</a>
+ */
+public class ClaraBuilderTest {
+
+    private final ClaraBuilder builder = new ClaraBuilder();
+
+    @Test
+    public void withController_setsController() {
+        assertNull("Controller should be null before withController call",
+                builder.getController());
+        final Object controllerInstance = new Object();
+
+        ClaraBuilder returnedBuilder = builder.withController(controllerInstance);
+
+        assertSame("Expected controller set after withController",
+                controllerInstance, builder.getController());
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void withAttributeFilter_addsFilter() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeFilters().isEmpty());
+        final AttributeFilter filter = new DummyAttributeFilter();
+
+        ClaraBuilder returnedBuilder = builder.withAttributeFilter(filter);
+
+        assertSameObjectsInList("filter", builder.getAttributeFilters(), filter);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void withAttributeFilters_addsFilters_inOrder() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeFilters().isEmpty());
+        final AttributeFilter filter1 = new DummyAttributeFilter();
+        final AttributeFilter filter2 = new DummyAttributeFilter();
+
+        ClaraBuilder returnedBuilder = builder.withAttributeFilters(filter1,
+                filter2);
+
+
+        assertSameObjectsInList("filter", builder.getAttributeFilters(),
+                filter1, filter2);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void combination_withAttributeFilter_withAttributeFilters_inOrder() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeFilters().isEmpty());
+        final AttributeFilter filter1 = new DummyAttributeFilter();
+        final AttributeFilter filter2 = new DummyAttributeFilter();
+        final AttributeFilter filter3 = new DummyAttributeFilter();
+        final AttributeFilter filter4 = new DummyAttributeFilter();
+
+        ClaraBuilder returnedBuilder = builder
+                .withAttributeFilter(filter1)
+                .withAttributeFilters(filter2, filter3)
+                .withAttributeFilter(filter4);
+
+        assertSameObjectsInList("filter", builder.getAttributeFilters(),
+                filter1, filter2, filter3, filter4);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void withAttributeParser_addsParser() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeParsers().isEmpty());
+        final AttributeParser parser = new DummyAttributeParser();
+
+        ClaraBuilder returnedBuilder = builder.withAttributeParser(parser);
+
+        assertSameObjectsInList("parser", builder.getAttributeParsers(),
+                parser);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void withAttributeParsers_addsParsers_inOrder() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeParsers().isEmpty());
+        final AttributeParser parser1 = new DummyAttributeParser();
+        final AttributeParser parser2 = new DummyAttributeParser();
+
+        ClaraBuilder returnedBuilder = builder.withAttributeParsers(parser1,
+                parser2);
+
+        assertSameObjectsInList("parser", builder.getAttributeParsers(),
+                parser1, parser2);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void combination_withAttributeParser_withAttributeParsers_inOrder() {
+        assertTrue("AttributeFilters should initially be empty",
+                builder.getAttributeParsers().isEmpty());
+        final AttributeParser parser1 = new DummyAttributeParser();
+        final AttributeParser parser2 = new DummyAttributeParser();
+        final AttributeParser parser3 = new DummyAttributeParser();
+        final AttributeParser parser4 = new DummyAttributeParser();
+
+        ClaraBuilder returnedBuilder = builder
+                .withAttributeParser(parser1)
+                .withAttributeParsers(parser2, parser3)
+                .withAttributeParser(parser4);
+
+        assertSameObjectsInList("parser", builder.getAttributeParsers(),
+                parser1, parser2, parser3, parser4);
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void createInflater_fullBuilder() {
+        final Object controller = new Object();
+        final AttributeFilter filter1 = new DummyAttributeFilter();
+        final AttributeFilter filter2 = new DummyAttributeFilter();
+        final AttributeParser parser1 = new DummyAttributeParser();
+        final AttributeParser parser2 = new DummyAttributeParser();
+
+        LayoutInflater inflater = builder
+                .withController(controller)
+                .withAttributeFilters(filter1, filter2)
+                .withAttributeParsers(parser1, parser2)
+                .createInflater();
+
+        assertNotNull(inflater);
+        // ideally we'd like to test whether the info in the builder
+        // also gets into the inflater; however this currently isn't exposed.
+    }
+
+    // ClaraBuilder#create(InputStream) is tested through ClaraTest
+
+    private void assertSameBuilder(ClaraBuilder returnedBuilder) {
+        assertSame("Expected same builder", builder, returnedBuilder);
+    }
+
+    private void assertSameObjectsInList(String objectTypeName,
+            List<?> objectsToCheck, Object... expectedObjects) {
+        assertEquals(String.format("Unexpected number of %ss", objectTypeName),
+                expectedObjects.length, objectsToCheck.size());
+
+        for (int idx = 0; idx < expectedObjects.length; idx++) {
+            assertSame(String.format("Unexpected %s object for position %d",
+                            objectTypeName, idx),
+                    expectedObjects[idx], objectsToCheck.get(idx));
+        }
+    }
+
+    private static class DummyAttributeFilter implements AttributeFilter {
+        @Override
+        public void filter(AttributeContext attributeContext)
+                throws AttributeFilterException {
+            // Do nothing
+        }
+    }
+
+    private static class DummyAttributeParser implements AttributeParser {
+        @Override
+        public boolean isSupported(Class<?> valueType) {
+            return false;
+        }
+
+        @Override
+        public Object getValueAs(String value, Class<?> valueType,
+                Component component) {
+            return null;
+        }
+    }
+}

--- a/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
 /**
  * Tests for {@link ClaraBuilder}.
  *
- * @author <a href="mailto:mrotteveel@bol.com>Mark Rotteveel</a>
+ * @author <a href="mailto:mrotteveel@bol.com">Mark Rotteveel</a>
  */
 public class ClaraBuilderTest {
 

--- a/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/ClaraBuilderTest.java
@@ -157,12 +157,23 @@ public class ClaraBuilderTest {
 
     @Test
     public void withIdPrefix_setsIdPrefix() {
-        assertNull("idPrefix should initially be empty", builder.getIdPrefix());
+        assertEquals("idPrefix should initially be empty", "", builder.getIdPrefix());
         final String idPrefix = "someIdPrefix";
 
         ClaraBuilder returnedBuilder = builder.withIdPrefix(idPrefix);
 
         assertEquals("Unexpected idPrefix", idPrefix, builder.getIdPrefix());
+        assertSameBuilder(returnedBuilder);
+    }
+
+    @Test
+    public void withIdPrefix_idPrefixTrimmed() {
+        assertEquals("idPrefix should initially be empty", "", builder.getIdPrefix());
+        final String idPrefix = "   someIdPrefix   ";
+
+        ClaraBuilder returnedBuilder = builder.withIdPrefix(idPrefix);
+
+        assertEquals("Unexpected idPrefix", idPrefix.trim(), builder.getIdPrefix());
         assertSameBuilder(returnedBuilder);
     }
 
@@ -238,6 +249,41 @@ public class ClaraBuilderTest {
                 (CustomComponentInflaterListener) layout.getComponent(0));
         assertCustomComponentInflaterListener("custom2",
                 (CustomComponentInflaterListener) layout.getComponent(1));
+    }
+
+    @Test
+    public void create_noIdPrefix_prefixOnAllComponentsWithId() {
+        VerticalLayout layout = (VerticalLayout) Clara.build()
+                .createFrom(getXml("hierarchy-with-ids.xml"));
+
+        assertHierarchyWithIds("", layout);
+    }
+
+    @Test
+    public void create_usingIdPrefix_prefixOnAllComponentsWithId() {
+        final String idPrefix = "myIdPrefix_";
+
+        VerticalLayout layout = (VerticalLayout) Clara.build()
+                .withIdPrefix(idPrefix)
+                .createFrom(getXml("hierarchy-with-ids.xml"));
+
+        assertHierarchyWithIds(idPrefix, layout);
+    }
+
+    private void assertHierarchyWithIds(String idPrefix, VerticalLayout layout) {
+        assertEquals(idPrefix + "id1", layout.getId());
+
+        Button button = (Button) layout.getComponent(0);
+        assertEquals(idPrefix + "id1_1", button.getId());
+
+        Panel panel = (Panel) layout.getComponent(1);
+        assertEquals(idPrefix + "id1_2", panel.getId());
+
+        Label label = (Label) panel.getContent();
+        assertEquals(idPrefix + "id1_2_1", label.getId());
+
+        HorizontalLayout horizontalLayout = (HorizontalLayout) layout.getComponent(2);
+        assertNull(horizontalLayout.getId());
     }
 
     private void assertSameBuilder(ClaraBuilder returnedBuilder) {

--- a/clara/src/test/java/org/vaadin/teemu/clara/ClaraTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/ClaraTest.java
@@ -2,6 +2,7 @@ package org.vaadin.teemu.clara;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -188,6 +189,11 @@ public class ClaraTest {
         };
         Component c = Clara.findComponentById(layout, "foobar");
         assertNull(c);
+    }
+
+    @Test
+    public void testBuild_nonNullResult() {
+        assertNotNull(Clara.build());
     }
 
     private InputStream getXml(String fileName) {

--- a/clara/src/test/java/org/vaadin/teemu/clara/CustomComponentInflaterListener.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/CustomComponentInflaterListener.java
@@ -1,0 +1,29 @@
+package org.vaadin.teemu.clara;
+
+
+import com.vaadin.ui.Component;
+import com.vaadin.ui.CustomComponent;
+import org.vaadin.teemu.clara.inflater.InflaterListener;
+
+/**
+ * Custom component that implements {@link InflaterListener}.
+ * <p>
+ * For testing purposes.
+ * </p>
+ */
+public class CustomComponentInflaterListener extends CustomComponent
+        implements InflaterListener{
+    @Override
+    public void componentInflated() {
+        Component root = Clara.build()
+                .withIdPrefix(getId() != null ? getId() + "_" : null)
+                .withController(this)
+                .createFrom("/hierarchy-with-ids.xml");
+        setCompositionRoot(root);
+    }
+
+    @Override
+    public Component getCompositionRoot() {
+        return super.getCompositionRoot();
+    }
+}

--- a/clara/src/test/java/org/vaadin/teemu/clara/inflater/LayoutInflaterTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/inflater/LayoutInflaterTest.java
@@ -264,38 +264,4 @@ public class LayoutInflaterTest {
                 1, layout.getComponentCountAfterInflate());
     }
 
-    @Test
-    public void inflate_noIdPrefix_prefixOnAllComponentsWithId() {
-        VerticalLayout layout = (VerticalLayout) inflater.inflate(
-                getXml("hierarchy-with-ids.xml"));
-
-        assertHierarchyWithIds("", layout);
-    }
-
-    @Test
-    public void inflate_usingIdPrefix_prefixOnAllComponentsWithId() {
-        final String idPrefix = "myIdPrefix_";
-        inflater.setIdPrefix(idPrefix);
-
-        VerticalLayout layout = (VerticalLayout) inflater.inflate(
-                getXml("hierarchy-with-ids.xml"));
-
-        assertHierarchyWithIds(idPrefix, layout);
-    }
-
-    private void assertHierarchyWithIds(String idPrefix, VerticalLayout layout) {
-        assertEquals(idPrefix + "id1", layout.getId());
-
-        Button button = (Button) layout.getComponent(0);
-        assertEquals(idPrefix + "id1_1", button.getId());
-
-        Panel panel = (Panel) layout.getComponent(1);
-        assertEquals(idPrefix + "id1_2", panel.getId());
-
-        Label label = (Label) panel.getContent();
-        assertEquals(idPrefix + "id1_2_1", label.getId());
-
-        HorizontalLayout horizontalLayout = (HorizontalLayout) layout.getComponent(2);
-        assertNull(horizontalLayout.getId());
-    }
 }

--- a/clara/src/test/java/org/vaadin/teemu/clara/inflater/VerticalLayoutWithInflaterListener.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/inflater/VerticalLayoutWithInflaterListener.java
@@ -1,0 +1,33 @@
+package org.vaadin.teemu.clara.inflater;
+
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * Layout for testing InflaterListener calls.
+ */
+public class VerticalLayoutWithInflaterListener extends VerticalLayout
+        implements InflaterListener {
+
+    private boolean componentInflatedCalled;
+    private String idAfterInflate;
+    private int componentCountAfterInflate;
+
+    @Override
+    public void componentInflated() {
+        componentInflatedCalled = true;
+        idAfterInflate = getId();
+        componentCountAfterInflate = getComponentCount();
+    }
+
+    public boolean isComponentInflatedCalled() {
+        return componentInflatedCalled;
+    }
+
+    public String getIdAfterInflate() {
+        return idAfterInflate;
+    }
+
+    public int getComponentCountAfterInflate() {
+        return componentCountAfterInflate;
+    }
+}

--- a/clara/src/test/resources/component-with-inflaterlistener.xml
+++ b/clara/src/test/resources/component-with-inflaterlistener.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test:VerticalLayoutWithInflaterListener id="idOfVerticalLayoutWithInflaterListener" xmlns="urn:import:com.vaadin.ui" xmlns:l="urn:vaadin:parent" xmlns:test="urn:import:org.vaadin.teemu.clara.inflater">
+    <Button l:expandRatio="1.0" />
+</test:VerticalLayoutWithInflaterListener>

--- a/clara/src/test/resources/hierarchy-with-ids.xml
+++ b/clara/src/test/resources/hierarchy-with-ids.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VerticalLayout id="id1" xmlns="urn:import:com.vaadin.ui">
+    <Button id="id1_1" width="200px" />
+    <Panel id="id1_2">
+        <Label id="id1_2_1"/>
+    </Panel>
+    <HorizontalLayout>
+        <!-- intentionally no id -->
+    </HorizontalLayout>
+</VerticalLayout>

--- a/clara/src/test/resources/org/vaadin/teemu/clara/component-reuse.xml
+++ b/clara/src/test/resources/org/vaadin/teemu/clara/component-reuse.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VerticalLayout id="root" xmlns="urn:import:com.vaadin.ui" xmlns:c="urn:import:org.vaadin.teemu.clara">
+    <c:CustomComponentInflaterListener id="custom1"/>
+    <c:CustomComponentInflaterListener id="custom2"/>
+</VerticalLayout>


### PR DESCRIPTION
At bol.com we are creating a number of screens that contain multiple instances of the same (reusable) component. We need to create unique ids (requirement in Vaadin, but also for our automated tests). We'd also like to be able to set non-primitive or non-string attributes, so we need to be able to add extra `AttributeParser` instances (eg setting the `Resource` of an `Image`).

To this end, this pull requests includes:
* Configuration/creation of the component tree using a builder pattern
* Option of prefixing ids (eg to be able to generate unique ids when reusing components)
* Listener so a component can be notified when it has been inflated
* Adding extra `AttributeParser` instances (only through the builder)

See also the addition to the readme.