### PR TITLE
Make inflater loosely coupled to reflection component provider

### DIFF
--- a/clara-demo/pom.xml
+++ b/clara-demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.vaadin.addons</groupId>
         <artifactId>clara-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>clara-demo</artifactId>
@@ -81,7 +81,7 @@
                 <version>${vaadin.plugin.version}</version>
                 <configuration>
                     <extraJvmArgs>-Xmx512M -Xss1024k</extraJvmArgs>
-                    <!-- We are doing "inplace" but into subdir VAADIN/widgetsets. This way 
+                    <!-- We are doing "inplace" but into subdir VAADIN/widgetsets. This way
                         compatible with Vaadin eclipse plugin. -->
                     <webappDirectory>${basedir}/src/main/webapp/VAADIN/widgetsets</webappDirectory>
                     <hostedWebapp>${basedir}/src/main/webapp/VAADIN/widgetsets</hostedWebapp>
@@ -97,7 +97,7 @@
                     <execution>
                         <configuration>
                             <modules>
-                                <module>org.vaadin.teemu.clara.demo.widgetset.ClaraDemoWidgetset</module> 
+                                <module>org.vaadin.teemu.clara.demo.widgetset.ClaraDemoWidgetset</module>
                             </modules>
                         </configuration>
                         <goals>

--- a/clara/pom.xml
+++ b/clara/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.vaadin.addons</groupId>
         <artifactId>clara-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>clara</artifactId>

--- a/clara/src/main/java/org/vaadin/teemu/clara/ClaraBuilder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/ClaraBuilder.java
@@ -1,13 +1,9 @@
 package org.vaadin.teemu.clara;
 
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
+import com.vaadin.ui.Component;
 import org.vaadin.teemu.clara.binder.Binder;
 import org.vaadin.teemu.clara.binder.BinderException;
+import org.vaadin.teemu.clara.inflater.ComponentProvider;
 import org.vaadin.teemu.clara.inflater.InflaterListener;
 import org.vaadin.teemu.clara.inflater.LayoutInflater;
 import org.vaadin.teemu.clara.inflater.LayoutInflaterException;
@@ -16,7 +12,11 @@ import org.vaadin.teemu.clara.inflater.filter.AttributeFilter;
 import org.vaadin.teemu.clara.inflater.filter.AttributeFilterException;
 import org.vaadin.teemu.clara.inflater.parser.AttributeParser;
 
-import com.vaadin.ui.Component;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Builder for configuring Clara.
@@ -28,6 +28,8 @@ public class ClaraBuilder {
     private Object controller;
     private final List<AttributeFilter> attributeFilters = new ArrayList<AttributeFilter>();
     private final List<AttributeParser> attributeParsers = new ArrayList<AttributeParser>();
+    private final List<ComponentProvider> componentProviders = new ArrayList<ComponentProvider>();
+
     private String idPrefix = "";
 
     /**
@@ -100,6 +102,37 @@ public class ClaraBuilder {
     }
 
     /**
+     * Adds a component provider.
+     *
+     * @param provider Component provider
+     * @return this builder
+     */
+    public ClaraBuilder withComponentProvider(ComponentProvider provider) {
+        return withComponentProviders(Collections.singletonList(provider));
+    }
+
+    /**
+     * Adds component providers.
+     *
+     * @param providers Component providers
+     * @return this builder
+     */
+    public ClaraBuilder withComponentProviders(ComponentProvider... providers) {
+        return withComponentProviders(Arrays.asList(providers));
+    }
+
+    /**
+     * Adds Component providers.
+     *
+     * @param providers Component providers
+     * @return this builder
+     */
+    public ClaraBuilder withComponentProviders(List<ComponentProvider> providers) {
+        componentProviders.addAll(providers);
+        return this;
+    }
+
+    /**
      * @return Unmodifiable list of the current attribute filters
      */
     public List<AttributeFilter> getAttributeFilters() {
@@ -168,8 +201,8 @@ public class ClaraBuilder {
 
         // Inflate the XML to a component (tree).
         LayoutInflater inflater = createInflater();
-        Component result = inflater.inflate(xml,
-                binder.getAlreadyAssignedFields(controller));
+        Component result = inflater.inflate(xml, binder.getAlreadyAssignedFields(controller),
+                componentProviders.toArray(new ComponentProvider[componentProviders.size()]));
 
         // Bind to controller.
         binder.bind(result, controller);

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/ComponentProvider.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/ComponentProvider.java
@@ -4,20 +4,26 @@ import com.vaadin.ui.Component;
 
 public interface ComponentProvider {
     /**
+     * @param uri the namespace URI of the node describing the requested
+     * component.
+     * @param localName the node name of the node describing the requested component.
+     * @param id (optional) the id of the requested component, or <code>null</code> if no
+     * id supplied.
+     * @return <code>true</code> if the provider is capable for providing a component defined by
+     * uri, localname and id, otherwise <code>false</code>.
+     */
+    boolean isApplicableFor(String uri, String localName, String id);
+
+    /**
      * Provides components given the uri, localName and/or id.
      *
-     * @param uri
-     *            the namespace URI of the node describing the requested
-     *            component.
-     * @param localName
-     *            the node name of the node describing the requested component.
-     * @param id
-     *            the id of the requested component, or <code>null</code> if no
-     *            id supplied.
+     * @param uri the namespace URI of the node describing the requested
+     * component.
+     * @param localName the node name of the node describing the requested component.
+     * @param id (optional) the id of the requested component, or <code>null</code> if no
+     * id supplied.
      * @return the component, based on uri, localName and/or id.
-     * @throws LayoutInflaterException
-     *             on failure to provide the component.
+     * @throws LayoutInflaterException on failure to provide the component.
      */
-    Component getComponent(String uri, String localName, String id)
-            throws LayoutInflaterException;
+    Component getComponent(String uri, String localName, String id) throws LayoutInflaterException;
 }

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/OverrideMapComponentProvider.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/OverrideMapComponentProvider.java
@@ -1,8 +1,8 @@
 package org.vaadin.teemu.clara.inflater;
 
-import java.util.Map;
-
 import com.vaadin.ui.Component;
+
+import java.util.Map;
 
 public class OverrideMapComponentProvider implements ComponentProvider {
     private final Map<String, Component> componentOverrideMap;
@@ -16,6 +16,11 @@ public class OverrideMapComponentProvider implements ComponentProvider {
     public OverrideMapComponentProvider(
             Map<String, Component> componentOverrideMap) {
         this.componentOverrideMap = componentOverrideMap;
+    }
+
+    @Override
+    public boolean isApplicableFor(String uri, String localName, String id) {
+        return componentOverrideMap.containsKey(id);
     }
 
     /**

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/ReflectionComponentProvider.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/ReflectionComponentProvider.java
@@ -1,12 +1,17 @@
 package org.vaadin.teemu.clara.inflater;
 
-import static org.vaadin.teemu.clara.inflater.LayoutInflater.IMPORT_URN_PREFIX;
-
 import com.vaadin.ui.Component;
+
+import static org.vaadin.teemu.clara.inflater.LayoutInflater.IMPORT_URN_PREFIX;
 
 public class ReflectionComponentProvider implements ComponentProvider {
 
     private final ComponentFactory componentFactory = new ComponentFactory();
+
+    @Override
+    public boolean isApplicableFor(String uri, String localName, String id) {
+        return uri.startsWith(IMPORT_URN_PREFIX);
+    }
 
     /**
      * {@inheritDoc}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.vaadin.addons</groupId>
     <artifactId>clara-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
 
     <name>Clara Parent Project</name>


### PR DESCRIPTION
Hi Teemu,

This merge request further adjusts Clara to apply a custom ComponentProvider to it. It turned out that the LayoutInflater still had a hard coded notion of the import URN. The matching of the XML nodes against the available ComponentProviders is now abstracted to the ComponentProvider implementations.

Hope you can merge this change soon and publish an updated version of Clara. Then I can publish the first revision of [Clara4Spring] (https://github.com/m-koops/Clara4Spring), an extension to Clara that allows components in a template to be autowired from Spring.

Thanks,
Mark