### PR TITLE
Improve detection of assigned fields

### DIFF
--- a/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/binder/Binder.java
@@ -121,10 +121,6 @@ public class Binder {
                 controller.getClass(), UiField.class)) {
             bindField(componentRoot, controller, field);
         }
-        Class<?> superclass = clazz.getSuperclass();
-        if (superclass != null) {
-            bindFields(componentRoot, controller, superclass);
-        }
     }
 
     private void bindMethods(Component componentRoot, Object controller) {
@@ -137,7 +133,6 @@ public class Binder {
                 controller.getClass(), UiHandler.class)) {
             bindEventHandler(componentRoot, controller, method);
         }
-
     }
 
     private void bindField(Component componentRoot, Object controller,

--- a/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/inflater/handler/AttributeHandler.java
@@ -19,7 +19,7 @@ import org.vaadin.teemu.clara.inflater.parser.ComponentPositionParser;
 import org.vaadin.teemu.clara.inflater.parser.EnumAttributeParser;
 import org.vaadin.teemu.clara.inflater.parser.PrimitiveAttributeParser;
 import org.vaadin.teemu.clara.inflater.parser.VaadinAttributeParser;
-import org.vaadin.teemu.clara.util.MethodComparator;
+import org.vaadin.teemu.clara.util.MethodsByDeprecationComparator;
 import org.vaadin.teemu.clara.util.ReflectionUtils.ParamCount;
 
 import com.vaadin.ui.Component;
@@ -50,7 +50,7 @@ public class AttributeHandler {
     /**
      * Returns the namespace of attributes this {@link AttributeHandler} is
      * interested in.
-     * 
+     *
      * @return XML namespace this handler is responsible for.
      */
     public String getNamespace() {
@@ -205,7 +205,7 @@ public class AttributeHandler {
      * Comparator to sort {@link Method}s into a preferred ordering taking into
      * account available parsers in addition to method deprecation.
      */
-    private class ParserAwareMethodComparator extends MethodComparator {
+    private class ParserAwareMethodComparator extends MethodsByDeprecationComparator {
 
         private Class<?> getPropertyClass(Method method) {
             Class<?>[] parameterTypes = method.getParameterTypes();

--- a/clara/src/main/java/org/vaadin/teemu/clara/util/MethodsByDeprecationComparator.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/util/MethodsByDeprecationComparator.java
@@ -7,7 +7,7 @@ import java.util.Comparator;
  * {@link Comparator} to sort {@link Method}s so that deprecated methods come
  * last.
  */
-public class MethodComparator implements Comparator<Method> {
+public class MethodsByDeprecationComparator implements Comparator<Method> {
 
     private boolean isDeprecated(Method method) {
         return method.isAnnotationPresent(Deprecated.class);

--- a/clara/src/main/java/org/vaadin/teemu/clara/util/ReflectionUtils.java
+++ b/clara/src/main/java/org/vaadin/teemu/clara/util/ReflectionUtils.java
@@ -1,11 +1,15 @@
 package org.vaadin.teemu.clara.util;
 
+import com.vaadin.ui.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-
-import com.vaadin.ui.Component;
 
 /**
  * Static utility methods leveraging the Java Reflection API.
@@ -40,7 +44,7 @@ public class ReflectionUtils {
      * Returns a {@link List} of {@link Method}s from the given {@code clazz}
      * {@link Class} that match the given {@code nameRegex} by method name and
      * has parameter count matching the given {@code numberOfParams}.
-     * 
+     *
      * @param clazz
      *            {@link Class} to find the methods from.
      * @param nameRegex
@@ -67,7 +71,7 @@ public class ReflectionUtils {
      * {@link Class} that match the given {@code nameRegex} by method name and
      * have the given {@code paramTypes} as method parameters. Use
      * {@link AnyClassOrPrimitive} to mark any parameter type.
-     * 
+     *
      * @param clazz
      *            {@link Class} to find the methods from.
      * @param nameRegex
@@ -103,7 +107,7 @@ public class ReflectionUtils {
     /**
      * Returns {@code true} if the given {@link Class} implements the
      * {@link Component} interface of Vaadin Framework otherwise {@code false}.
-     * 
+     *
      * @param componentClass
      *            {@link Class} to check against {@link Component} interface.
      * @return {@code true} if the given {@link Class} is a {@link Component},
@@ -116,4 +120,50 @@ public class ReflectionUtils {
             return false;
         }
     }
+
+    public static List<Field> getAllDeclaredFields(Class<?> type) {
+        List<Field> fields = new ArrayList<Field>();
+
+        for (Class<?> baseType = type; baseType != null; baseType = baseType.getSuperclass()) {
+            fields.addAll(Arrays.asList(baseType.getDeclaredFields()));
+        }
+
+        return fields;
+    }
+
+    public static List<Field> getAllDeclaredFieldsAnnotatedWith(Class<?> type,
+            Class<? extends Annotation> annotationType) {
+        List<Field> fields = ReflectionUtils.getAllDeclaredFields(type);
+        filterByAnnotationType(fields, annotationType);
+        return fields;
+    }
+
+    public static List<Method> getAllDeclaredMethods(Class<?> type) {
+        List<Method> methods = new ArrayList<Method>();
+
+        for (Class<?> baseType = type; baseType != null; baseType = baseType.getSuperclass()) {
+            methods.addAll(Arrays.asList(baseType.getDeclaredMethods()));
+        }
+
+        return methods;
+    }
+
+    public static List<Method> getAllDeclaredMethodsAnnotatedWith(Class<?> type,
+            Class<? extends Annotation> annotationType) {
+        List<Method> methods = ReflectionUtils.getAllDeclaredMethods(type);
+        filterByAnnotationType(methods, annotationType);
+        return methods;
+    }
+
+    private static void filterByAnnotationType(List<? extends AnnotatedElement> fields,
+            Class<? extends Annotation> annotationType) {
+        Iterator<? extends AnnotatedElement> it = fields.iterator();
+        while (it.hasNext()) {
+            AnnotatedElement field = it.next();
+            if (!field.isAnnotationPresent(annotationType)) {
+                it.remove();
+            }
+        }
+    }
+
 }

--- a/clara/src/test/java/org/vaadin/teemu/clara/binder/BinderTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/binder/BinderTest.java
@@ -6,7 +6,6 @@ import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.DateField;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.vaadin.teemu.clara.binder.annotation.UiDataSource;
 import org.vaadin.teemu.clara.binder.annotation.UiField;
@@ -103,7 +102,6 @@ public class BinderTest {
         assertEquals(1, assignedFields.size());
     }
 
-    @Ignore("needs adjustment in Binder")
     @Test
     public void getAlreadyAssignedFields_yieldFieldFromBaseClass() {
         SubcontrollerWithoutFieldBinding controller =

--- a/clara/src/test/java/org/vaadin/teemu/clara/binder/BinderTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/binder/BinderTest.java
@@ -1,11 +1,17 @@
 package org.vaadin.teemu.clara.binder;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import com.vaadin.data.Property;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.DateField;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.vaadin.teemu.clara.binder.annotation.UiDataSource;
+import org.vaadin.teemu.clara.binder.annotation.UiField;
+import org.vaadin.teemu.clara.binder.annotation.UiHandler;
+import org.vaadin.teemu.clara.inflater.LayoutInflater;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -17,18 +23,15 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Date;
+import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.vaadin.teemu.clara.binder.annotation.UiDataSource;
-import org.vaadin.teemu.clara.binder.annotation.UiField;
-import org.vaadin.teemu.clara.binder.annotation.UiHandler;
-import org.vaadin.teemu.clara.inflater.LayoutInflater;
-
-import com.vaadin.data.Property;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.Button.ClickEvent;
-import com.vaadin.ui.DateField;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BinderTest {
 
@@ -76,19 +79,38 @@ public class BinderTest {
         binder.bind(button, controller);
 
         // check that the field is correctly set
-        assertTrue(controller.myButton == button);
+        assertSame(button, controller.getMyButton());
     }
 
     @Test
     public void bind_field_fieldOfSuperclassSetCorrectly() {
         Button button = (Button) inflater.inflate(getXml("single-button.xml"));
 
-        ControllerWithFieldBinding controller = new SubcontrollerWithoutFieldBinding();
+        SubcontrollerWithoutFieldBinding controller = new SubcontrollerWithoutFieldBinding();
         Binder binder = new Binder();
         binder.bind(button, controller);
 
         // check that the field is correctly set
-        assertTrue(controller.myButton == button);
+        assertSame(button, controller.getMyButton());
+    }
+
+    @Test
+    public void getAlreadyAssignedFields_yieldFieldFromClass() {
+        ControllerWithFieldBinding controller =
+                new ControllerWithFieldBinding(new Button("myButton"));
+        Binder binder = new Binder();
+        Map<String, Component> assignedFields = binder.getAlreadyAssignedFields(controller);
+        assertEquals(1, assignedFields.size());
+    }
+
+    @Ignore("needs adjustment in Binder")
+    @Test
+    public void getAlreadyAssignedFields_yieldFieldFromBaseClass() {
+        SubcontrollerWithoutFieldBinding controller =
+                new SubcontrollerWithoutFieldBinding(new Button("myButton"));
+        Binder binder = new Binder();
+        Map<String, Component> assignedFields = binder.getAlreadyAssignedFields(controller);
+        assertEquals(1, assignedFields.size());
     }
 
     @Test(expected = BinderException.class)
@@ -129,7 +151,7 @@ public class BinderTest {
         binder.bind(button, controller);
 
         // check that the field is correctly set
-        assertTrue(controller.myButton == button);
+        assertSame(button, controller.myButton);
     }
 
     @Test
@@ -223,6 +245,14 @@ public class BinderTest {
         @UiField("myButton")
         private Button myButton;
 
+        public ControllerWithFieldBinding() {
+            // do nothing
+        }
+
+        public ControllerWithFieldBinding(Button button) {
+            myButton = button;
+        }
+
         public Button getMyButton() {
             return myButton;
         }
@@ -232,6 +262,13 @@ public class BinderTest {
     public static class SubcontrollerWithoutFieldBinding extends
             ControllerWithFieldBinding {
 
+        public SubcontrollerWithoutFieldBinding() {
+            super();
+        }
+
+        public SubcontrollerWithoutFieldBinding(Button button) {
+            super(button);
+        }
     }
 
     public static class ControllerWithFieldBindingOfMissingId {

--- a/clara/src/test/java/org/vaadin/teemu/clara/inflater/CustomVerticalLayout.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/inflater/CustomVerticalLayout.java
@@ -1,10 +1,16 @@
 package org.vaadin.teemu.clara.inflater;
 
 import com.vaadin.ui.Component;
+import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
+import org.vaadin.teemu.clara.binder.annotation.UiField;
 
 @SuppressWarnings("serial")
 public class CustomVerticalLayout extends VerticalLayout {
+    public static final TextField TEXT_FIELD = new TextField();
+
+    @UiField
+    private TextField textField = TEXT_FIELD;
 
     @Deprecated
     public void setExpandRatio(Component c, String e) {

--- a/clara/src/test/java/org/vaadin/teemu/clara/util/MethodsByDeprecationComparatorTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/util/MethodsByDeprecationComparatorTest.java
@@ -1,15 +1,15 @@
 package org.vaadin.teemu.clara.util;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
-public class MethodComparatorTest {
+public class MethodsByDeprecationComparatorTest {
 
     private interface InterfaceToTest {
         void test();
@@ -24,7 +24,7 @@ public class MethodComparatorTest {
     public void testMethodComparator() {
         List<Method> methods = Arrays
                 .asList(InterfaceToTest.class.getMethods());
-        Collections.sort(methods, new MethodComparator());
+        Collections.sort(methods, new MethodsByDeprecationComparator());
 
         // Deprecated method is now last.
         assertEquals(methods.get(2).getName(), "test2");

--- a/clara/src/test/java/org/vaadin/teemu/clara/util/ReflectionUtilsTest.java
+++ b/clara/src/test/java/org/vaadin/teemu/clara/util/ReflectionUtilsTest.java
@@ -1,25 +1,60 @@
 package org.vaadin.teemu.clara.util;
 
+import com.vaadin.data.Container;
+import com.vaadin.data.Property;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.TextField;
+import org.junit.Test;
+import org.vaadin.teemu.clara.binder.annotation.UiDataSource;
+import org.vaadin.teemu.clara.binder.annotation.UiField;
+import org.vaadin.teemu.clara.binder.annotation.UiHandler;
+import org.vaadin.teemu.clara.util.ReflectionUtils.ParamCount;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.vaadin.teemu.clara.util.ReflectionUtils.findMethods;
+import static org.vaadin.teemu.clara.util.ReflectionUtils.getAllDeclaredFields;
+import static org.vaadin.teemu.clara.util.ReflectionUtils.getAllDeclaredFieldsAnnotatedWith;
+import static org.vaadin.teemu.clara.util.ReflectionUtils.getAllDeclaredMethods;
+import static org.vaadin.teemu.clara.util.ReflectionUtils.getAllDeclaredMethodsAnnotatedWith;
 import static org.vaadin.teemu.clara.util.ReflectionUtils.isComponent;
-
-import org.junit.Test;
-import org.vaadin.teemu.clara.util.ReflectionUtils.ParamCount;
-
-import com.vaadin.ui.Button;
 
 public class ReflectionUtilsTest {
 
-    public static class ClassToExamine {
+    public static class BaseClassToExamine {
+        private String stringBase;
+        @UiField("textFieldFromBase")
+        private TextField textFieldBase;
 
-        public void setFooBar() {
+        public void setFooBar(String foo) {
             // NOP
         }
 
-        public void setFooBar(String foo) {
+        @UiHandler("handlerFromBase")
+        public void onValueChangedBase(Property.ValueChangeEvent e) {
+            // NOP
+        }
+
+        @UiDataSource("dataSourceFromBase")
+        public Container getDataFromBase() {
+            return null;
+        }
+
+    }
+
+    public static class SubClassToExamine extends BaseClassToExamine{
+        private String stringSub;
+        @UiField("textFieldFromSub")
+        private TextField textFieldSub;
+
+        public void setFooBar() {
             // NOP
         }
 
@@ -31,78 +66,181 @@ public class ReflectionUtilsTest {
             // NOP
         }
 
+        @UiHandler("handlerFromSub")
+        public void onValueChangedSub(Property.ValueChangeEvent e) {
+            // NOP
+        }
+
+        @UiDataSource("dataSourceFromSub")
+        public Container getDataFromSub() {
+            return null;
+        }
+    }
+
+    private static class FieldByNameComparator implements Comparator<Field> {
+        @Override
+        public int compare(Field left, Field right) {
+            return left.getName().compareTo(right.getName());
+        }
+    }
+
+
+    private static class MethodByNameComparator implements Comparator<Method> {
+        @Override
+        public int compare(Method left, Method right) {
+            return left.getName().compareTo(right.getName());
+        }
     }
 
     @Test
     public void test_findMethodsByRegexAndType() {
-        assertEquals(1,
-                findMethods(ClassToExamine.class, "setFoo(.*)", String.class)
-                        .size());
+        assertEquals(1, findMethods(SubClassToExamine.class, "setFoo(.*)", String.class).size());
     }
 
     @Test
     public void test_findMethodsByRegexAndTypeUsingAny() {
-        assertEquals(
-                1,
-                findMethods(
-                        ClassToExamine.class,
-                        "setFoo(.*)",
-                        new Class<?>[] { String.class,
-                                AnyClassOrPrimitive.class }).size());
+        assertEquals(1, findMethods(SubClassToExamine.class, "setFoo(.*)",
+                new Class<?>[] { String.class, AnyClassOrPrimitive.class }).size());
     }
 
     @Test
     public void test_findMethodsByRegexAndTypeAsNull() {
-        assertEquals(
-                1,
-                findMethods(ClassToExamine.class, "setFoo(.*)",
-                        (Class<?>[]) null).size());
+        assertEquals(1, findMethods(SubClassToExamine.class, "setFoo(.*)", (Class<?>[]) null).size());
     }
 
     @Test
     public void test_findMethodsByRegExAndParamCount() {
-        assertEquals(
-                4,
-                findMethods(ClassToExamine.class, "setFoo(.*)",
-                        ParamCount.fromTo(0, 2)).size());
+        assertEquals(4,
+                findMethods(SubClassToExamine.class, "setFoo(.*)", ParamCount.fromTo(0, 2)).size());
     }
 
     @Test
     public void test_findMethodsByConstantParamCount_constant0() {
-        assertEquals(
-                1,
-                findMethods(ClassToExamine.class, "setFooBar",
-                        ParamCount.constant(0)).size());
+        assertEquals(1,
+                findMethods(SubClassToExamine.class, "setFooBar", ParamCount.constant(0)).size());
     }
 
     @Test
     public void test_findMethodsByConstantParamCount_constant1() {
-        assertEquals(
-                2,
-                findMethods(ClassToExamine.class, "setFooBar",
-                        ParamCount.constant(1)).size());
+        assertEquals(2,
+                findMethods(SubClassToExamine.class, "setFooBar", ParamCount.constant(1)).size());
     }
 
     @Test
     public void test_findMethodsByConstantParamCount_constant2() {
-        assertEquals(
-                1,
-                findMethods(ClassToExamine.class, "setFooBar",
-                        ParamCount.constant(2)).size());
+        assertEquals(1,
+                findMethods(SubClassToExamine.class, "setFooBar", ParamCount.constant(2)).size());
     }
 
     @Test
     public void test_findMethodsByConstantParamCount_constant3() {
-        assertEquals(
-                0,
-                findMethods(ClassToExamine.class, "setFooBar",
-                        ParamCount.constant(3)).size());
+        assertEquals(0,
+                findMethods(SubClassToExamine.class, "setFooBar", ParamCount.constant(3)).size());
     }
 
     @Test
     public void test_isComponent() {
         assertTrue(isComponent(Button.class));
-        assertFalse(isComponent(ClassToExamine.class));
+        assertFalse(isComponent(SubClassToExamine.class));
         assertFalse(isComponent(null));
     }
+
+    @Test
+    public void test_getAllDeclaredFieldsFromBaseClass() {
+        List<Field> fields = getAllDeclaredFields(BaseClassToExamine.class);
+        assertEquals(2, fields.size());
+
+        Collections.sort(fields, new FieldByNameComparator());
+
+        assertEquals("stringBase", fields.get(0).getName());
+        assertEquals("textFieldBase", fields.get(1).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredFieldsFromSubClass() {
+        List<Field> fields = getAllDeclaredFields(SubClassToExamine.class);
+        assertEquals(4, fields.size());
+
+        Collections.sort(fields, new FieldByNameComparator());
+
+        assertEquals("stringBase", fields.get(0).getName());
+        assertEquals("stringSub", fields.get(1).getName());
+        assertEquals("textFieldBase", fields.get(2).getName());
+        assertEquals("textFieldSub", fields.get(3).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredMethodsFromBaseClass() {
+        List<Method> methods = getAllDeclaredMethods(BaseClassToExamine.class);
+        assertEquals(15, methods.size());
+
+        methods.removeAll(getAllDeclaredMethods(Object.class));
+        assertEquals(3, methods.size());
+
+        Collections.sort(methods, new MethodByNameComparator());
+
+        assertEquals("getDataFromBase", methods.get(0).getName());
+        assertEquals("onValueChangedBase", methods.get(1).getName());
+        assertEquals("setFooBar", methods.get(2).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredMethodsFromSubClass() {
+        List<Method> methods = getAllDeclaredMethods(SubClassToExamine.class);
+        assertEquals(20, methods.size());
+
+        methods.removeAll(getAllDeclaredMethods(Object.class));
+        assertEquals(8, methods.size());
+        Collections.sort(methods, new MethodByNameComparator());
+
+        assertEquals("getDataFromBase", methods.get(0).getName());
+        assertEquals("getDataFromSub", methods.get(1).getName());
+        assertEquals("onValueChangedBase", methods.get(2).getName());
+        assertEquals("onValueChangedSub", methods.get(3).getName());
+        assertEquals("setFooBar", methods.get(4).getName());
+        assertEquals("setFooBar", methods.get(5).getName());
+        assertEquals("setFooBar", methods.get(6).getName());
+        assertEquals("setFooBar", methods.get(7).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredFieldsFromBaseClassByAnnotation() {
+        List<Field> fields = getAllDeclaredFieldsAnnotatedWith(BaseClassToExamine.class,
+                UiField.class);
+        assertEquals(1, fields.size());
+        assertEquals("textFieldBase", fields.get(0).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredFieldsFromSubClassByAnnotation() {
+        List<Field> fields = getAllDeclaredFieldsAnnotatedWith(SubClassToExamine.class,
+                UiField.class);
+        assertEquals(2, fields.size());
+
+        Collections.sort(fields, new FieldByNameComparator());
+
+        assertEquals("textFieldBase", fields.get(0).getName());
+        assertEquals("textFieldSub", fields.get(1).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredMethodsFromBaseClassByAnnotation() {
+        List<Method> methods = getAllDeclaredMethodsAnnotatedWith(BaseClassToExamine.class,
+                UiHandler.class);
+        assertEquals(1, methods.size());
+        assertEquals("onValueChangedBase", methods.get(0).getName());
+    }
+
+    @Test
+    public void test_getAllDeclaredMethodsFromSubClassByAnnotation() {
+        List<Method> methods = getAllDeclaredMethodsAnnotatedWith(SubClassToExamine.class,
+                UiDataSource.class);
+        assertEquals(2, methods.size());
+
+        Collections.sort(methods, new MethodByNameComparator());
+
+        assertEquals("getDataFromBase", methods.get(0).getName());
+        assertEquals("getDataFromSub", methods.get(1).getName());
+    }
+
 }


### PR DESCRIPTION
Hi Teemu,

Me again with an improvement to Clara. I noticed that assigned fields from base classes were not detected properly.

To fix this, I have unified detection of fields and methods by annotation through the full class hierarchy of controller. The detection methods are now part of ReflectionUtils and are unit tested on their own.

Also added 2 test cases to BinderTest to expose the failing detection that was fixed.

Can you prepare a new Clara release for this?

Thanks,
Mark